### PR TITLE
Add enso highlight animation

### DIFF
--- a/enso.js
+++ b/enso.js
@@ -1,0 +1,29 @@
+const ensoStar = {
+  x: canvas.width / 2,
+  y: canvas.height / 2,
+  radius: 2,
+  alpha: 0.2
+};
+
+function drawHighlightStar() {
+  // Enlarge and brighten gradually
+  if (ensoStar.radius < 8) ensoStar.radius += 0.05;
+  if (ensoStar.alpha < 1) ensoStar.alpha += 0.01;
+
+  // Draw the glowing star
+  ctx.beginPath();
+  ctx.arc(ensoStar.x, ensoStar.y, ensoStar.radius, 0, Math.PI * 2);
+  ctx.fillStyle = `rgba(255, 255, 200, ${ensoStar.alpha})`;
+  ctx.shadowColor = 'white';
+  ctx.shadowBlur = 15;
+  ctx.fill();
+
+  // Draw the enso circle around it
+  ctx.beginPath();
+  ctx.arc(ensoStar.x, ensoStar.y, ensoStar.radius + 15, 0, 2 * Math.PI);
+  ctx.strokeStyle = `rgba(255, 255, 255, 0.5)`;
+  ctx.lineWidth = 2;
+  ctx.setLineDash([5, 5]); // optional: dashed effect
+  ctx.stroke();
+  ctx.setLineDash([]); // reset
+}

--- a/starfield.html
+++ b/starfield.html
@@ -8,5 +8,6 @@
 <body>
   <canvas id="starfield"></canvas>
   <script src="stars.js"></script>
+  <script src="enso.js"></script>
 </body>
 </html>

--- a/stars.js
+++ b/stars.js
@@ -52,6 +52,11 @@ function drawStars() {
   ctx.fill();
   // Reset shadow so other stars are not affected
   ctx.shadowBlur = 0;
+
+  // If highlight logic is defined in enso.js, call it here
+  if (typeof drawHighlightStar === 'function') {
+    drawHighlightStar();
+  }
   requestAnimationFrame(drawStars);
 }
 


### PR DESCRIPTION
## Summary
- draw an enso highlight around a starfield star
- include optional highlight call in star drawing
- load new script in `starfield.html`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685841d156c0832f905b9c8905775a34