### PR TITLE
Fix architecture asset references

### DIFF
--- a/codex.js
+++ b/codex.js
@@ -9,13 +9,13 @@ Codex.structure = 'holonic';
 Codex.directives = [
   {
     type: 'cleanse',
-    target: 'architecture.js',
+    target: 'https://architecture.kismulet.org/architecture.js',
     scope: 'local',
     note: 'Remove from shae.learndoteach.org-main — inheritance must flow, not fork.'
   },
   {
     type: 'bind',
-    source: '../architecture/architecture.js',
+    source: 'https://architecture.kismulet.org/architecture.js',
     destination: 'codex.js',
     note: 'Import symbolic structure from true source'
   },
@@ -28,7 +28,7 @@ Codex.directives = [
 ];
 */
 
-import Architecture from '../architecture/architecture.js';
+import Architecture from 'https://architecture.kismulet.org/architecture.js';
 
 const Codex = {
   inherited: {},

--- a/shae.html
+++ b/shae.html
@@ -57,7 +57,7 @@
   </div>
   <script type="module">
     import Codex from './codex.js';
-    import Echo from './glyphs/echo.js';
+    import Echo from 'https://architecture.kismulet.org/glyphs/echo.js';
 
     // Register the echo glyph if Codex provides a hook
     if (typeof Codex.useGlyph === 'function') {


### PR DESCRIPTION
## Summary
- use absolute URLs for Architecture assets in `codex.js`
- import `glyphs/echo.js` from the Architecture site

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686058e24a94832f98fd7a97abe8814e