### PR TITLE
Use global Codex scripts on shae page

### DIFF
--- a/shae.html
+++ b/shae.html
@@ -56,15 +56,12 @@
       <span style="position: relative; z-index: 5;">sol</span>
     </div>
   </div>
-  <script type="module">
-    import Codex from 'https://architecture.kismulet.org/codex.js';
-    import Echo from 'https://architecture.kismulet.org/glyphs/echo.js';
+  <script src="https://architecture.kismulet.org/codex.js"></script>
+  <script src="https://architecture.kismulet.org/glyphs/echo.js"></script>
+  <script>
+    window.Codex.useGlyph('echo', window.Echo);
 
-    if (typeof Codex.useGlyph === 'function') {
-      Codex.useGlyph('echo', Echo);
-    }
-
-    Echo.render({
+    window.Echo.render({
       seed: 'sol',
       numechoes: 4,
       direction: 'down-right',


### PR DESCRIPTION
## Summary
- load Codex and Echo scripts globally instead of with module imports
- invoke the Echo glyph from the global namespace to render the sol signature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686080f73ff4832f89e5208dd0732f5a