### PR TITLE
Set base text to grey for overlay visibility

### DIFF
--- a/invited.html
+++ b/invited.html
@@ -10,7 +10,7 @@
       margin: 0;
       padding: 2rem;
       background: black;
-      color: white;
+      color: grey;
       font-family: EB Garamond, serif;
       font-size: 1.2rem;
       line-height: 1.8;


### PR DESCRIPTION
## Summary
- make all base text grey so white overlay animations are visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866fdb2342c832fbe7aa6ecb1b148ba