### PR TITLE
Fix breathe button layout shift

### DIFF
--- a/invited.html
+++ b/invited.html
@@ -117,7 +117,7 @@
   Your browser does not support the audio element.
 </audio>
 
-<button id="breathe-button" style="
+  <button id="breathe-button" style="
   margin-top: 2rem;
   background: none;
   border: 1px solid #666;
@@ -128,11 +128,13 @@
   cursor: pointer;
   transition: opacity 1s ease;
   opacity: 0;
-  display: none;
-">breathe</button>
+  visibility: hidden;
+  pointer-events: none;
+  display: block;
+  ">breathe</button>
 
 <div id="doc-link" style="opacity: 0; margin-top: 4rem; transition: opacity 2s; color: #dddddd; font-size: 1.2rem;">
-  <a href="https://docs.google.com/document/d/1WF0NB9fnxhDPEi_arGSp18Kev9KXdoX-IePIE8KJgCQ/edit" target="_blank" rel="noopener noreferrer">
+  <a href="https://docs.google.com/document/d/14P3OR151cU5M1byNgjIhUcjHDiIKh3Tky4ToJa5zOSg/edit?usp=sharing" target="_blank" rel="noopener noreferrer">
     Read or comment in the shared Google Doc
   </a>
 </div>
@@ -162,7 +164,8 @@
 
   // After feather lands, reveal the breathe button
   setTimeout(() => {
-    button.style.display = 'block';
+    button.style.visibility = 'visible';
+    button.style.pointerEvents = 'auto';
     setTimeout(() => {
       button.style.opacity = 1;
     }, 100);


### PR DESCRIPTION
## Summary
- keep space for breathe button to stop page jumping
- change docs link to the updated Google Doc

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68672165aba0832fbb4e2ee146ee9651