### PR TITLE
Fix button fade to avoid layout shift

### DIFF
--- a/invited.html
+++ b/invited.html
@@ -146,7 +146,10 @@
 
   button.addEventListener('click', () => {
     button.style.opacity = 0;
-    setTimeout(() => button.style.display = 'none', 1000);
+    button.style.pointerEvents = 'none';
+    setTimeout(() => {
+      button.style.visibility = 'hidden';
+    }, 1000);
 
     if (audio) {
       audio.play().catch(err => {


### PR DESCRIPTION
## Summary
- hide the button with visibility instead of removing it so the rest of the page doesn't jump when pressed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686723a42b68832f99e1b27673c85197