### PR TITLE
Add replay option after audio ends

### DIFF
--- a/invited.html
+++ b/invited.html
@@ -122,7 +122,7 @@
 </div>
 
 <script src="feather.js"></script>
-<audio id="background-audio" loop style="position: absolute; top: 1rem; left: 1rem;">
+<audio id="background-audio" style="position: absolute; top: 1rem; left: 1rem;">
   <source src="opus-23-in-f-major.mp3" type="audio/mpeg">
   Your browser does not support the audio element.
 </audio>
@@ -171,6 +171,16 @@
       setTimeout(() => docLink.style.opacity = 1, 2000);
     }
   });
+
+  if (audio) {
+    audio.addEventListener('ended', () => {
+      button.style.visibility = 'visible';
+      button.style.pointerEvents = 'auto';
+      setTimeout(() => {
+        button.style.opacity = 1;
+      }, 100);
+    });
+  }
 
   // Load falling feather
   renderFeather(document.getElementById('feather-inline'));


### PR DESCRIPTION
## Summary
- play the background music once instead of looping
- restore the *breathe* button when the song finishes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6867280c9778832f9ffbd13652d295e2