### PR TITLE
Adjust intro timing and audio volume

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,8 @@
     };
 
     window.addEventListener('load', () => {
-      setTimeout(() => { intro.style.opacity = 1; }, 500);
+      // Delay the initial message so it fades in 8 seconds after load
+      setTimeout(() => { intro.style.opacity = 1; }, 8000);
     });
 
     const startExperience = () => {
@@ -121,9 +122,11 @@
 
           audio.volume = 0;
           audio.play().then(() => {
-            const fade = fadeAudio('in', 3000, 0.3);
-            setTimeout(() => fadeAudio('out', 3000, 0.3), (audio.duration * 1000) - 3000);
-            setTimeout(() => { whisper.style.opacity = 0; }, 10000);
+            // Fade the cello in quietly and out at the same level
+            const fade = fadeAudio('in', 3000, 0.15);
+            setTimeout(() => fadeAudio('out', 3000, 0.15), (audio.duration * 1000) - 3000);
+            // Keep the whisper visible a bit longer
+            setTimeout(() => { whisper.style.opacity = 0; }, 20000);
           });
         }
       }, 20000);


### PR DESCRIPTION
## Summary
- delay fade-in of intro text until 8s after page load
- keep the whisper text visible longer
- play background cello at half the previous volume

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867305d6fa4832f8cfdc41de5c08afb