### PR TITLE
Fix whisper flash after audio ends

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,13 @@
             const fade = fadeAudio('in', 3000, 0.15);
             setTimeout(() => fadeAudio('out', 3000, 0.15), (audio.duration * 1000) - 3000);
             // Keep the whisper visible a bit longer
-            setTimeout(() => { whisper.style.opacity = 0; }, 20000);
+            setTimeout(() => {
+              whisper.style.opacity = 0;
+              // Remove the text entirely after it fades out so it
+              // doesn't flash again when the audio finishes
+              setTimeout(() => whisper.remove(), 2000);
+            }, 20000);
+            audio.addEventListener('ended', () => whisper.remove());
           });
         }
       }, 20000);


### PR DESCRIPTION
## Summary
- prevent the whisper from reappearing after the audio stops

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686735ce2f98832f89f64fa30a278cbe